### PR TITLE
Add new instruments, ensure WAV output directory exists, and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If the quality of the performance of **Baba O’Riley** seemed inappropriate —
 
 ## Features
 - Playback of events (notes) from `JSON`.
-- Support for different instruments (e.g., `Kick`).
+- Support for different instruments (`Kick`, `Snare`, `BassSynth`, `PolySynth`, `ArpSynth`).
 - Rendering to mono `WAV` (16-bit PCM).
 - Multithreaded generation: each instrument is processed in its own goroutine.
 
@@ -49,7 +49,6 @@ and be registered in `instruments`.
 Example: the Kick (bass drum) is synthesized as a decaying sine wave.
 
 ## TODO
-- Add more instruments (snare, bass, synth).
 - Implement stereo support.
 - MIDI import/export.
 - Real-time player.

--- a/internal/audio/wavwriter.go
+++ b/internal/audio/wavwriter.go
@@ -3,6 +3,7 @@ package audio
 import (
 	"encoding/binary"
 	"os"
+	"path/filepath"
 )
 
 // WAVWriter represents an object for writing WAV files
@@ -27,7 +28,11 @@ func writeOrFail(f *os.File, data any) error {
 // sampleRate - sampling rate in Hz
 // durationSec - duration of the file in seconds
 func NewWAV(filename string, sampleRate int, durationSec int) (*WAVWriter, error) {
-	pesPath := "out/" + filename + ".wav"
+	pesPath := filepath.Join("out", filename+".wav")
+	if err := os.MkdirAll(filepath.Dir(pesPath), 0o755); err != nil {
+		return nil, err
+	}
+
 	f, err := os.Create(pesPath)
 	if err != nil {
 		return nil, err

--- a/internal/audio/wavwriter_test.go
+++ b/internal/audio/wavwriter_test.go
@@ -1,0 +1,31 @@
+package audio
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewWAVCreatesOutDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir temp: %v", err)
+	}
+
+	w, err := NewWAV("test", 44100, 1)
+	if err != nil {
+		t.Fatalf("NewWAV returned error: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	outPath := filepath.Join("out", "test.wav")
+	if _, err := os.Stat(outPath); err != nil {
+		t.Fatalf("expected wav file %q to exist: %v", outPath, err)
+	}
+}

--- a/internal/instruments/bass.go
+++ b/internal/instruments/bass.go
@@ -1,0 +1,32 @@
+package instruments
+
+import "math"
+
+// BassSynth generates a warm bass waveform with a light harmonic mix.
+type BassSynth struct {
+	id int
+}
+
+// Play generates bass samples for the provided note.
+func (b *BassSynth) Play(note int, velocity int, duration float64, sampleRate int) []int16 {
+	numSamples := int(duration * float64(sampleRate))
+	buf := make([]int16, numSamples)
+	freq := 55.0 * math.Pow(2, float64(note-33)/12.0)
+	amp := float64(velocity)
+
+	for i := 0; i < numSamples; i++ {
+		t := float64(i) / float64(sampleRate)
+		env := 1.0
+		releaseStart := math.Max(0.0, duration-0.05)
+		if t > releaseStart {
+			env = math.Exp(-40.0 * (t - releaseStart))
+		}
+
+		fundamental := math.Sin(2 * math.Pi * freq * t)
+		harmonic := 0.35 * math.Sin(2*math.Pi*freq*2*t)
+		sample := (fundamental + harmonic) * env * amp
+		buf[i] = int16(sample)
+	}
+
+	return buf
+}

--- a/internal/instruments/factory.go
+++ b/internal/instruments/factory.go
@@ -40,6 +40,15 @@ func GetInstrument(name string) Instrument {
 	case strings.HasPrefix(name, "kick"):
 		inst = &Kick{id: getNextID()}
 		log.Printf("[Factory] Created Kick instrument for name '%s', object address: %p\n", name, inst)
+	case strings.HasPrefix(name, "snare"):
+		inst = &Snare{id: getNextID()}
+		log.Printf("[Factory] Created Snare instrument for name '%s', object address: %p\n", name, inst)
+	case strings.HasPrefix(name, "bass"):
+		inst = &BassSynth{id: getNextID()}
+		log.Printf("[Factory] Created BassSynth instrument for name '%s', object address: %p\n", name, inst)
+	case strings.HasPrefix(name, "synth"):
+		inst = &PolySynth{id: getNextID()}
+		log.Printf("[Factory] Created PolySynth instrument for name '%s', object address: %p\n", name, inst)
 	case strings.HasPrefix(name, "arp"):
 		inst = &ArpSynth{id: getNextID()}
 		log.Printf("[Factory] Created ArpSynth instrument for name '%s', object address: %p\n", name, inst)

--- a/internal/instruments/factory_test.go
+++ b/internal/instruments/factory_test.go
@@ -1,0 +1,46 @@
+package instruments
+
+import "testing"
+
+func TestGetInstrumentByPrefix(t *testing.T) {
+	InstrumentInstances = map[string]Instrument{}
+	nextInstrumentID = 0
+
+	cases := []struct {
+		name string
+		want any
+	}{
+		{name: "kick1", want: &Kick{}},
+		{name: "snare1", want: &Snare{}},
+		{name: "bass1", want: &BassSynth{}},
+		{name: "synth1", want: &PolySynth{}},
+		{name: "arp1", want: &ArpSynth{}},
+		{name: "unknown", want: &ArpSynth{}},
+	}
+
+	for _, tc := range cases {
+		got := GetInstrument(tc.name)
+		switch tc.want.(type) {
+		case *Kick:
+			if _, ok := got.(*Kick); !ok {
+				t.Fatalf("%s: expected *Kick, got %T", tc.name, got)
+			}
+		case *Snare:
+			if _, ok := got.(*Snare); !ok {
+				t.Fatalf("%s: expected *Snare, got %T", tc.name, got)
+			}
+		case *BassSynth:
+			if _, ok := got.(*BassSynth); !ok {
+				t.Fatalf("%s: expected *BassSynth, got %T", tc.name, got)
+			}
+		case *PolySynth:
+			if _, ok := got.(*PolySynth); !ok {
+				t.Fatalf("%s: expected *PolySynth, got %T", tc.name, got)
+			}
+		case *ArpSynth:
+			if _, ok := got.(*ArpSynth); !ok {
+				t.Fatalf("%s: expected *ArpSynth, got %T", tc.name, got)
+			}
+		}
+	}
+}

--- a/internal/instruments/snare.go
+++ b/internal/instruments/snare.go
@@ -1,0 +1,38 @@
+package instruments
+
+import "math"
+
+// Snare is a lightweight synthesized snare drum (noise + short tone).
+type Snare struct {
+	id int
+}
+
+// Play generates a percussive snare-like sound.
+func (s *Snare) Play(note int, velocity int, duration float64, sampleRate int) []int16 {
+	numSamples := int(duration * float64(sampleRate))
+	if numSamples < sampleRate/20 {
+		numSamples = sampleRate / 20
+	}
+
+	buf := make([]int16, numSamples)
+	amp := float64(velocity)
+	toneFreq := 180.0 * math.Pow(2, float64(note-60)/24.0)
+
+	// Deterministic pseudo-noise so rendering is reproducible across runs.
+	var noiseState uint32 = uint32(note*131 + velocity*17 + 1)
+
+	for i := 0; i < numSamples; i++ {
+		t := float64(i) / float64(sampleRate)
+		noiseEnv := math.Exp(-24.0 * t)
+		toneEnv := math.Exp(-12.0 * t)
+
+		noiseState = noiseState*1664525 + 1013904223
+		noise := (float64(noiseState>>16)/32767.5 - 1.0) * noiseEnv
+
+		tone := math.Sin(2*math.Pi*toneFreq*t) * toneEnv * 0.35
+		sample := (noise*0.65 + tone) * amp
+		buf[i] = int16(sample)
+	}
+
+	return buf
+}

--- a/internal/instruments/synth.go
+++ b/internal/instruments/synth.go
@@ -1,0 +1,39 @@
+package instruments
+
+import "math"
+
+// PolySynth is a simple polyphonic-style lead pad sound.
+type PolySynth struct {
+	id int
+}
+
+// Play generates a bright, slightly detuned waveform.
+func (p *PolySynth) Play(note int, velocity int, duration float64, sampleRate int) []int16 {
+	numSamples := int(duration * float64(sampleRate))
+	buf := make([]int16, numSamples)
+	baseFreq := 440.0 * math.Pow(2, float64(note-69)/12.0)
+	amp := float64(velocity)
+
+	attack := math.Min(duration*0.2, 0.03)
+	release := math.Min(duration*0.25, 0.08)
+
+	for i := 0; i < numSamples; i++ {
+		t := float64(i) / float64(sampleRate)
+
+		env := 1.0
+		if attack > 0 && t < attack {
+			env = t / attack
+		}
+		if release > 0 && t > duration-release {
+			env *= math.Max(0, (duration-t)/release)
+		}
+
+		osc1 := math.Sin(2 * math.Pi * baseFreq * t)
+		osc2 := math.Sin(2 * math.Pi * baseFreq * 1.005 * t)
+		osc3 := math.Sin(2 * math.Pi * baseFreq * 0.997 * t)
+		sample := (osc1 + 0.6*osc2 + 0.6*osc3) * 0.5 * env * amp
+		buf[i] = int16(sample)
+	}
+
+	return buf
+}


### PR DESCRIPTION
### Motivation
- Add richer instrument palette and register them in the factory so sequenced JSON can target `snare`, `bass`, and `synth` sounds.
- Ensure WAV output is reliably written by creating the `out/` directory when needed.
- Provide automated tests to validate the WAV writer and instrument factory behavior.

### Description
- Updated `README.md` to list new supported instruments (`Kick`, `Snare`, `BassSynth`, `PolySynth`, `ArpSynth`).
- Modified `internal/audio/wavwriter.go` to construct the output path with `filepath.Join("out", filename+".wav")` and create the output directory with `os.MkdirAll` before creating the file.
- Added new instrument implementations `Snare`, `BassSynth`, and `PolySynth` under `internal/instruments` with simple deterministic synthesis in their `Play` methods.
- Extended the instrument factory in `internal/instruments/factory.go` to recognize `snare`, `bass`, and `synth` name prefixes and log created instances, and added unit tests `internal/audio/wavwriter_test.go` and `internal/instruments/factory_test.go`.

### Testing
- Ran `go test ./...` which executed the new tests `TestNewWAVCreatesOutDirectory` and `TestGetInstrumentByPrefix`.
- All tests completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8c71e2e988323874524e0c0b9e466)